### PR TITLE
[WIP] Add hooks to logger

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -309,6 +309,18 @@ was called:
     log.Info(ctx, "two")
 ```
 
+#### Hook
+
+Hooks can be added to the logger that are notified when an entry is logged:
+
+```go
+    type myHook struct { }
+    func (h *myHook) OnLogged(entry *LogEntry) error { ... }
+
+    ctx = log.WithConfigs(log.AddHook(myHook{})).Onto(context.Background())
+    log.Info(ctx, "message") // log entry sent to hook
+```
+
 #### Custom configuration
 
 It is possible to create your own configuration. You will have to create an object that implements 

--- a/log/api_test.go
+++ b/log/api_test.go
@@ -25,6 +25,12 @@ type fieldsTest struct {
 	expected      frozen.Map
 }
 
+type testHook struct { }
+
+func (h *testHook) OnLogged(entry *LogEntry) error {
+	return nil
+}
+
 func TestMainDebug(t *testing.T) {
 	t.Parallel()
 
@@ -173,6 +179,16 @@ func TestWithConfigOutput(t *testing.T) {
 	setLogMockAssertion(logger, frozen.NewMap())
 	logger.On("SetOutput", &bytes.Buffer{}).Return(nil)
 	WithConfigs(SetOutput(&bytes.Buffer{})).WithLogger(logger).From(context.Background())
+	logger.AssertExpectations(t)
+}
+
+func TestWithHooks(t *testing.T) {
+	t.Parallel()
+
+	logger := newMockLogger()
+	setLogMockAssertion(logger, frozen.NewMap())
+	logger.On("AddHooks", mock.Anything).Return(nil)
+	WithConfigs(AddHooks(&testHook{})).WithLogger(logger).From(context.Background())
 	logger.AssertExpectations(t)
 }
 

--- a/log/config.go
+++ b/log/config.go
@@ -12,6 +12,7 @@ const (
 const (
 	verbosity internalTypeKey = iota
 	output
+	addHooks
 	logCaller
 )
 
@@ -25,6 +26,7 @@ type jsonFormat struct{}
 
 type verboseMode struct{ on bool }
 type outputConfig struct{ writer io.Writer }
+type addHooksConfig struct{ hooks []Hook }
 type logCallerConfig struct{ on bool }
 
 func NewStandardFormat() Config             { return standardFormat{} }
@@ -57,6 +59,17 @@ func (outputConfig) TypeKey() interface{} { return output }
 
 func (o outputConfig) Apply(logger Logger) error {
 	return logger.(SettableOutput).SetOutput(o.writer)
+}
+
+// AddHooks adds the given hooks to the logger.
+func AddHooks(hooks ...Hook) Config {
+	return addHooksConfig{hooks}
+}
+
+func (addHooksConfig) TypeKey() interface{} { return addHooks }
+
+func (o addHooksConfig) Apply(logger Logger) error {
+	return logger.(AddableHooks).AddHooks(o.hooks...)
 }
 
 // SetLogCaller sets whether or not a reference to the calling function is logged.

--- a/log/loggerInterface.go
+++ b/log/loggerInterface.go
@@ -53,6 +53,11 @@ type CodeReference struct {
 	Line int
 }
 
+// Hook describes a callback to receive notice when an entry is logged
+type Hook interface {
+	OnLogged(*LogEntry) error
+}
+
 type copyable interface {
 	// Copy returns a logger whose data is copied from the caller.
 	Copy() Logger
@@ -82,6 +87,11 @@ type SettableVerbosity interface {
 type SettableOutput interface {
 	// SetOutput sets where the logger outputs to.
 	SetOutput(w io.Writer) error
+}
+
+type AddableHooks interface {
+	// AddHooks adds the given hooks to the logger.
+	AddHooks(hooks ...Hook) error
 }
 
 type SettableLogCaller interface {

--- a/log/logrus.go
+++ b/log/logrus.go
@@ -65,6 +65,19 @@ func logrusEntryToPkgLogEntry(entry *logrus.Entry) *LogEntry {
 	}
 }
 
+// Component to convert a pkg hook into a logrus hook.
+type pkgHookToLogrusHook struct {
+	hook Hook
+}
+
+func (h pkgHookToLogrusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h pkgHookToLogrusHook) Fire(entry *logrus.Entry) error {
+	return h.hook.OnLogged(logrusEntryToPkgLogEntry(entry))
+}
+
 // Convert the pkg concept of verbosity to a logrus level.
 func verboseToLogrusLevel(verbose bool) logrus.Level {
 	if verbose {

--- a/log/mockLogger.go
+++ b/log/mockLogger.go
@@ -60,6 +60,10 @@ func (m *mockLogger) SetOutput(w io.Writer) error {
 	return m.Called(w).Error(0)
 }
 
+func (m *mockLogger) AddHooks(hooks ...Hook) error {
+	return m.Called(hooks).Error(0)
+}
+
 func (m *mockLogger) SetLogCaller(on bool) error {
 	return m.Called(on).Error(0)
 }

--- a/log/nullLogger.go
+++ b/log/nullLogger.go
@@ -63,6 +63,10 @@ func (n *nullLogger) SetOutput(w io.Writer) error {
 	return n.internal.SetOutput(w)
 }
 
+func (n *nullLogger) AddHooks(hooks ...Hook) error {
+	return n.internal.AddHooks(hooks...)
+}
+
 func (n *nullLogger) SetLogCaller(on bool) error {
 	return n.internal.SetLogCaller(on)
 }

--- a/log/standardLogger.go
+++ b/log/standardLogger.go
@@ -147,6 +147,13 @@ func (sl *standardLogger) SetOutput(w io.Writer) error {
 	return nil
 }
 
+func (sl *standardLogger) AddHooks(hooks ...Hook) error {
+	for _, hook := range hooks {
+		sl.internal.AddHook(pkgHookToLogrusHook{hook})
+	}
+	return nil
+}
+
 func (sl *standardLogger) SetLogCaller(on bool) error {
 	sl.logCaller = on
 	return nil


### PR DESCRIPTION
Preview: Hooks are callbacks that are called when a log entry is logged.